### PR TITLE
chore: Replace hardhat-waffle with newer hardhat tools

### DIFF
--- a/eth/hardhat.config.ts
+++ b/eth/hardhat.config.ts
@@ -4,7 +4,7 @@
 // organize-imports-ignore
 
 import '@nomiclabs/hardhat-ethers';
-import '@nomiclabs/hardhat-waffle';
+import '@nomicfoundation/hardhat-chai-matchers';
 import 'hardhat-abi-exporter';
 import 'hardhat-diamond-abi';
 // Must be registered after hardhat-diamond-abi

--- a/eth/package.json
+++ b/eth/package.json
@@ -15,8 +15,9 @@
     "@graphprotocol/graph-cli": "0.24.1",
     "@graphprotocol/graph-ts": "0.24.1",
     "@iarna/toml": "^2.2.5",
+    "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.6",
     "@nomiclabs/hardhat-ethers": "^2.1.1",
-    "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@projectsophon/workspace": "^1.0.0",
     "@solidstate/contracts": "0.0.29",
     "@solidstate/hardhat-4byte-uploader": "^1.0.2",
@@ -39,7 +40,6 @@
     "dockerode": "^3.2.1",
     "dotenv": "^10.0.0",
     "eslint": "^7.30.0",
-    "ethereum-waffle": "^3.2.2",
     "ethers": "^5.5.1",
     "hardhat": "^2.11.2",
     "hardhat-abi-exporter": "^2.10.0",
@@ -59,9 +59,6 @@
     "typechain": "^5.0.1",
     "typescript": "4.5.x",
     "wait-on": "^6.0.0"
-  },
-  "resolutions": {
-    "ganache-core": "npm:ganache@^7.0.3"
   },
   "engines": {
     "node": ">=16"

--- a/eth/test/DFArtifacts.test.ts
+++ b/eth/test/DFArtifacts.test.ts
@@ -1,4 +1,5 @@
 import { ArtifactRarity, ArtifactType, Biome } from '@darkforest_eth/types';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { BigNumberish } from 'ethers';
 import hre from 'hardhat';
@@ -6,7 +7,6 @@ import { TestLocation } from './utils/TestLocation';
 import {
   conquerUnownedPlanet,
   createArtifactOnPlanet,
-  fixtureLoader,
   getArtifactsOwnedBy,
   getCurrentTime,
   getStatSum,
@@ -38,7 +38,7 @@ describe('DarkForestArtifacts', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
 
     // Initialize player
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
@@ -72,7 +72,7 @@ describe('DarkForestArtifacts', function () {
 
   beforeEach('load fixture', async function () {
     this.timeout(0);
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   async function getArtifactsOnPlanet(world: World, locationId: BigNumberish) {

--- a/eth/test/DFHat.test.ts
+++ b/eth/test/DFHat.test.ts
@@ -1,6 +1,7 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { BN_ZERO, fixtureLoader, makeInitArgs } from './utils/TestUtils';
+import { BN_ZERO, makeInitArgs } from './utils/TestUtils';
 import { defaultWorldFixture, World } from './utils/TestWorld';
 import { SPAWN_PLANET_1 } from './utils/WorldConstants';
 
@@ -8,13 +9,13 @@ describe('DarkForestHat', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     return world;
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('should buy hats', async function () {

--- a/eth/test/DFInitialize.test.ts
+++ b/eth/test/DFInitialize.test.ts
@@ -1,5 +1,6 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import { fixtureLoader, makeInitArgs, makeRevealArgs, ZERO_ADDRESS } from './utils/TestUtils';
+import { makeInitArgs, makeRevealArgs, ZERO_ADDRESS } from './utils/TestUtils';
 import { defaultWorldFixture, World } from './utils/TestWorld';
 import {
   ADMIN_PLANET,
@@ -18,7 +19,7 @@ describe('DarkForestInit', function () {
   let world: World;
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(defaultWorldFixture);
+    world = await loadFixture(defaultWorldFixture);
   });
 
   it('initializes player successfully with the correct planet value', async function () {

--- a/eth/test/DFMove.test.ts
+++ b/eth/test/DFMove.test.ts
@@ -1,5 +1,5 @@
 import { ArtifactType } from '@darkforest_eth/types';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
@@ -836,9 +836,7 @@ describe('move rate limits', function () {
 
     await world.user1Core.move(...moveArgs);
 
-    await ethers.provider.send('evm_increaseTime', [
-      from.range.toNumber() / (from.speed.toNumber() / 100) - 10,
-    ]);
+    await time.increase(from.range.toNumber() / (from.speed.toNumber() / 100) - 10);
 
     // do 5 moves after some time
 
@@ -849,7 +847,7 @@ describe('move rate limits', function () {
 
     await expect(world.user1Core.move(...moveArgs)).to.be.revertedWith('Planet is rate-limited');
 
-    await ethers.provider.send('evm_increaseTime', [20]);
+    await time.increase(20);
 
     // first move should be done
 

--- a/eth/test/DFMove.test.ts
+++ b/eth/test/DFMove.test.ts
@@ -1,11 +1,11 @@
 import { ArtifactType } from '@darkforest_eth/types';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 import {
   conquerUnownedPlanet,
   createArtifactOnPlanet,
-  fixtureLoader,
   increaseBlockchainTime,
   makeInitArgs,
   makeMoveArgs,
@@ -33,7 +33,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
       let initArgs = makeInitArgs(SPAWN_PLANET_1);
       await world.user1Core.initializePlayer(...initArgs);
       await world.user1Core.giveSpaceShips(SPAWN_PLANET_1.id);
@@ -47,7 +47,7 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it('allows controller to move ships to places they do not own with infinite distance', async function () {
@@ -129,7 +129,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
       const initArgs = makeInitArgs(SPAWN_PLANET_1);
 
       await world.user1Core.initializePlayer(...initArgs);
@@ -138,7 +138,7 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it("should add space junk to the user's total space junk", async function () {
@@ -162,7 +162,7 @@ describe('DarkForestMove', function () {
   describe('move to an enemy planet', function () {
     let world: World;
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
 
       let initArgs = makeInitArgs(SPAWN_PLANET_1);
       await world.user1Core.initializePlayer(...initArgs);
@@ -177,7 +177,7 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it("should not add space junk to the user's total space junk", async function () {
@@ -199,7 +199,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
       const initArgs = makeInitArgs(SPAWN_PLANET_1);
 
       await world.user1Core.initializePlayer(...initArgs);
@@ -224,7 +224,7 @@ describe('DarkForestMove', function () {
       return world;
     }
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it("removes space junk from the user's total", async function () {
@@ -249,7 +249,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      world = await fixtureLoader(defaultWorldFixture);
+      world = await loadFixture(defaultWorldFixture);
       const initArgs = makeInitArgs(SPAWN_PLANET_1);
 
       await world.user1Core.initializePlayer(...initArgs);
@@ -263,13 +263,13 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it('reverts', async function () {
       await expect(
         world.user1Core.move(...makeMoveArgs(LVL1_ASTEROID_1, SPAWN_PLANET_2, 100, 50000, 0, 0, 1))
-      ).to.be.revertedWith('Cannot abandon a planet that has incoming voyages');
+      ).to.be.revertedWith('Cannot abandon a planet that has incoming voyages.');
     });
   });
 
@@ -277,7 +277,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
       let initArgs = makeInitArgs(SPAWN_PLANET_1);
       await world.user1Core.initializePlayer(...initArgs);
       initArgs = makeInitArgs(SPAWN_PLANET_2);
@@ -292,13 +292,13 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it('reverts', async function () {
       await expect(
         world.user1Core.move(...makeMoveArgs(LVL1_ASTEROID_1, SPAWN_PLANET_2, 100, 50000, 0, 0, 1))
-      ).to.be.revertedWith('Cannot abandon a planet that has incoming voyages');
+      ).to.be.revertedWith('Cannot abandon a planet that has incoming voyages.');
     });
   });
 
@@ -306,7 +306,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
       const initArgs = makeInitArgs(SPAWN_PLANET_1);
 
       await world.user1Core.initializePlayer(...initArgs);
@@ -323,7 +323,7 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it('should emit event', async function () {
@@ -479,7 +479,7 @@ describe('DarkForestMove', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(growingWorldFixture);
+      const world = await loadFixture(growingWorldFixture);
       initialRadius = await world.contract.worldRadius();
       const initArgs = makeInitArgs(SPAWN_PLANET_2, initialRadius.toNumber());
 
@@ -490,7 +490,7 @@ describe('DarkForestMove', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it('should expand world radius when init high level planet', async function () {
@@ -511,7 +511,7 @@ describe('move to friendly planet', function () {
   let world: World;
 
   before(async function () {
-    world = await fixtureLoader(defaultWorldFixture);
+    world = await loadFixture(defaultWorldFixture);
 
     const dist = 10;
     const shipsSent = 40000;
@@ -635,7 +635,7 @@ describe('move to enemy planet', function () {
   let world: World;
 
   before(async function () {
-    world = await fixtureLoader(defaultWorldFixture);
+    world = await loadFixture(defaultWorldFixture);
 
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     await world.user2Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_2));
@@ -732,7 +732,7 @@ describe('reject move with insufficient resources', function () {
   let world: World;
 
   beforeEach(async function () {
-    world = await fixtureLoader(defaultWorldFixture);
+    world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
   });
 
@@ -806,7 +806,7 @@ describe('move rate limits', function () {
   let world: World;
 
   beforeEach(async function () {
-    world = await fixtureLoader(defaultWorldFixture);
+    world = await loadFixture(defaultWorldFixture);
 
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     await world.user2Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_2));

--- a/eth/test/DFPlanet.test.ts
+++ b/eth/test/DFPlanet.test.ts
@@ -1,8 +1,8 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import {
   conquerUnownedPlanet,
   feedSilverToCap,
-  fixtureLoader,
   increaseBlockchainTime,
   makeInitArgs,
   makeMoveArgs,
@@ -40,7 +40,7 @@ describe('DarkForestPlanet', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     await world.user2Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_2));
 
@@ -106,7 +106,7 @@ describe('DarkForestPlanet', function () {
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('clips level in nebula and space', async function () {

--- a/eth/test/DFPlanetTransfer.test.ts
+++ b/eth/test/DFPlanetTransfer.test.ts
@@ -1,11 +1,7 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import {
-  fixtureLoader,
-  increaseBlockchainTime,
-  makeInitArgs,
-  makeMoveArgs,
-} from './utils/TestUtils';
+import { increaseBlockchainTime, makeInitArgs, makeMoveArgs } from './utils/TestUtils';
 import { defaultWorldFixture, noPlanetTransferFixture, World } from './utils/TestWorld';
 import { LVL0_PLANET_POPCAP_BOOSTED, SPAWN_PLANET_1, SPAWN_PLANET_2 } from './utils/WorldConstants';
 
@@ -16,7 +12,7 @@ describe('DarkForestTransferPlanet', function () {
 
   describe("when transferring is disabled it doesn't work", async function () {
     before(async function () {
-      world = await fixtureLoader(noPlanetTransferFixture);
+      world = await loadFixture(noPlanetTransferFixture);
       await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     });
 
@@ -35,7 +31,7 @@ describe('DarkForestTransferPlanet', function () {
     let world: World;
 
     before(async function () {
-      world = await fixtureLoader(defaultWorldFixture);
+      world = await loadFixture(defaultWorldFixture);
       await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     });
 

--- a/eth/test/DFRefresh.test.ts
+++ b/eth/test/DFRefresh.test.ts
@@ -1,7 +1,7 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
-  fixtureLoader,
   increaseBlockchainTime,
   makeInitArgs,
   makeMoveArgs,
@@ -25,13 +25,13 @@ describe('DarkForestRefresh', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     return world;
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('should increase population over time', async function () {

--- a/eth/test/DFReveal.test.ts
+++ b/eth/test/DFReveal.test.ts
@@ -1,10 +1,6 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import {
-  fixtureLoader,
-  increaseBlockchainTime,
-  makeInitArgs,
-  makeRevealArgs,
-} from './utils/TestUtils';
+import { increaseBlockchainTime, makeInitArgs, makeRevealArgs } from './utils/TestUtils';
 import { defaultWorldFixture, World } from './utils/TestWorld';
 import { INVALID_PLANET, SPAWN_PLANET_1, SPAWN_PLANET_2 } from './utils/WorldConstants';
 
@@ -12,13 +8,13 @@ describe('DarkForestReveal', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     return world;
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it("allows player to reveal location of planet that doesn't exist in contract yet", async function () {

--- a/eth/test/DFRewards.test.ts
+++ b/eth/test/DFRewards.test.ts
@@ -1,6 +1,7 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { fixtureLoader, makeInitArgs } from './utils/TestUtils';
+import { makeInitArgs } from './utils/TestUtils';
 import { defaultWorldFixture, World } from './utils/TestWorld';
 import { SPAWN_PLANET_1, SPAWN_PLANET_2 } from './utils/WorldConstants';
 const { utils } = ethers;
@@ -9,7 +10,7 @@ describe('DarkForestRewards', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
     await world.user2Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_2));
     await world.contract.setTokenMintEndTime(0);
@@ -18,7 +19,7 @@ describe('DarkForestRewards', function () {
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('when a player submits a correctly sorted score array, it transfers XDAI to them based on their rank', async function () {

--- a/eth/test/DFScoringRound2.test.ts
+++ b/eth/test/DFScoringRound2.test.ts
@@ -1,10 +1,6 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import {
-  conquerUnownedPlanet,
-  feedSilverToCap,
-  fixtureLoader,
-  makeInitArgs,
-} from './utils/TestUtils';
+import { conquerUnownedPlanet, feedSilverToCap, makeInitArgs } from './utils/TestUtils';
 import { defaultWorldFixture, World } from './utils/TestWorld';
 import { LVL1_ASTEROID_1, LVL3_SPACETIME_1, SPAWN_PLANET_1 } from './utils/WorldConstants';
 
@@ -15,7 +11,7 @@ describe('DFScoringRound2', async function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
 
     // Conquer MINE_REGULAR and LVL3_SPACETIME_1 to accumulate silver
@@ -29,7 +25,7 @@ describe('DFScoringRound2', async function () {
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('allows player to withdraw silver from trading posts', async function () {

--- a/eth/test/DFScoringRound3.test.ts
+++ b/eth/test/DFScoringRound3.test.ts
@@ -1,10 +1,10 @@
 //@ts-nocheck Because we can't run these tests
 import { modPBigInt } from '@darkforest_eth/hashing';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { BigNumber, constants, ethers } from 'ethers';
 import {
   conquerUnownedPlanet,
-  fixtureLoader,
   increaseBlockchainTime,
   makeInitArgs,
   makeRevealArgs,
@@ -28,7 +28,7 @@ describe.skip('DarkForestScoringRound3', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     await world.user1Core.initializePlayer(...makeInitArgs(SPAWN_PLANET_1));
 
     // Conquer initial planets
@@ -39,7 +39,7 @@ describe.skip('DarkForestScoringRound3', function () {
 
   beforeEach('load fixture', async function () {
     this.timeout(0);
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('allows player to claim self-owned planet for score (positive x/y)', async function () {

--- a/eth/test/DFSpaceShips.test.ts
+++ b/eth/test/DFSpaceShips.test.ts
@@ -1,8 +1,8 @@
 import { ArtifactType } from '@darkforest_eth/types';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import {
   conquerUnownedPlanet,
-  fixtureLoader,
   increaseBlockchainTime,
   makeInitArgs,
   makeMoveArgs,
@@ -20,7 +20,7 @@ describe('Space Ships', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(defaultWorldFixture);
+    const world = await loadFixture(defaultWorldFixture);
     let initArgs = makeInitArgs(SPAWN_PLANET_1);
     await world.user1Core.initializePlayer(...initArgs);
     await world.user1Core.giveSpaceShips(SPAWN_PLANET_1.id);
@@ -34,7 +34,7 @@ describe('Space Ships', function () {
   }
 
   beforeEach(async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   describe('spawning your ships', function () {
@@ -108,7 +108,7 @@ describe('Space Ships', function () {
     let world: World;
 
     async function worldFixture() {
-      const world = await fixtureLoader(defaultWorldFixture);
+      const world = await loadFixture(defaultWorldFixture);
       const initArgs = makeInitArgs(SPAWN_PLANET_2);
       await world.user2Core.initializePlayer(...initArgs);
 
@@ -118,7 +118,7 @@ describe('Space Ships', function () {
     }
 
     beforeEach(async function () {
-      world = await fixtureLoader(worldFixture);
+      world = await loadFixture(worldFixture);
     });
 
     it('reverts', async function () {

--- a/eth/test/DFUpgrade.test.ts
+++ b/eth/test/DFUpgrade.test.ts
@@ -1,9 +1,9 @@
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
   conquerUnownedPlanet,
   feedSilverToCap,
-  fixtureLoader,
   increaseBlockchainTime,
   makeInitArgs,
 } from './utils/TestUtils';
@@ -25,7 +25,7 @@ describe('DarkForestUpgrade', function () {
   let world: World;
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(defaultWorldFixture);
+    world = await loadFixture(defaultWorldFixture);
   });
 
   it('should reject if planet not initialized', async function () {

--- a/eth/test/DFWhitelist.test.ts
+++ b/eth/test/DFWhitelist.test.ts
@@ -1,8 +1,9 @@
 import { EthAddress } from '@darkforest_eth/types';
 import { generateKeys, keyHash } from '@darkforest_eth/whitelist';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { fixtureLoader, makeInitArgs, makeWhitelistArgs } from './utils/TestUtils';
+import { makeInitArgs, makeWhitelistArgs } from './utils/TestUtils';
 import { whilelistWorldFixture, World } from './utils/TestWorld';
 import { SPAWN_PLANET_1 } from './utils/WorldConstants';
 
@@ -14,14 +15,14 @@ describe('DarkForestWhitelist', function () {
   let world: World;
 
   async function worldFixture() {
-    const world = await fixtureLoader(whilelistWorldFixture);
+    const world = await loadFixture(whilelistWorldFixture);
     await world.contract.addKeys(keyHashes);
 
     return world;
   }
 
   beforeEach('load fixture', async function () {
-    world = await fixtureLoader(worldFixture);
+    world = await loadFixture(worldFixture);
   });
 
   it('allows a user to register with a valid key', async function () {

--- a/eth/test/utils/TestUtils.ts
+++ b/eth/test/utils/TestUtils.ts
@@ -10,16 +10,14 @@ import {
 } from '@darkforest_eth/snarks';
 import { ArtifactRarity, ArtifactType, Biome } from '@darkforest_eth/types';
 import { bigIntFromKey } from '@darkforest_eth/whitelist';
+import { mine, time } from '@nomicfoundation/hardhat-network-helpers';
 import bigInt from 'big-integer';
-import { BigNumber, BigNumberish } from 'ethers';
-import { ethers, waffle } from 'hardhat';
+import { BigNumber, BigNumberish, constants } from 'ethers';
 // @ts-ignore
 import * as snarkjs from 'snarkjs';
 import { TestLocation } from './TestLocation';
 import { World } from './TestWorld';
 import { ARTIFACT_PLANET_1, initializers, LARGE_INTERVAL } from './WorldConstants';
-
-const { constants } = ethers;
 
 const {
   PLANETHASH_KEY,
@@ -32,8 +30,6 @@ const {
 
 export const ZERO_ADDRESS = constants.AddressZero;
 export const BN_ZERO = constants.Zero;
-
-export const fixtureLoader = waffle.createFixtureLoader();
 
 export function hexToBigNumber(hex: string): BigNumber {
   return BigNumber.from(`0x${hex}`);
@@ -219,12 +215,12 @@ export function makeFindArtifactArgs(
  * interval is measured in seconds
  */
 export async function increaseBlockchainTime(interval = LARGE_INTERVAL) {
-  await ethers.provider.send('evm_increaseTime', [interval]);
-  await ethers.provider.send('evm_mine', []);
+  await time.increase(interval);
+  await mine();
 }
 
 export async function getCurrentTime() {
-  return (await ethers.provider.getBlock('latest')).timestamp;
+  return time.latest();
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,8 +176,9 @@
         "@graphprotocol/graph-cli": "0.24.1",
         "@graphprotocol/graph-ts": "0.24.1",
         "@iarna/toml": "^2.2.5",
+        "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.6",
         "@nomiclabs/hardhat-ethers": "^2.1.1",
-        "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@projectsophon/workspace": "^1.0.0",
         "@solidstate/contracts": "0.0.29",
         "@solidstate/hardhat-4byte-uploader": "^1.0.2",
@@ -200,7 +201,6 @@
         "dockerode": "^3.2.1",
         "dotenv": "^10.0.0",
         "eslint": "^7.30.0",
-        "ethereum-waffle": "^3.2.2",
         "ethers": "^5.5.1",
         "hardhat": "^2.11.2",
         "hardhat-abi-exporter": "^2.10.0",
@@ -2329,393 +2329,6 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "license": "MIT"
     },
-    "node_modules/@ensdomains/ens": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz",
-      "integrity": "sha512-JSvpj1iNMFjK6K+uVl4unqMoa9rf5jopb8cya5UGBWz23Nw8hSNT7efgUx4BTlAPAgpNlEioUfeTyQ6J9ZvTVw==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "dependencies": {
-        "bluebird": "^3.5.2",
-        "eth-ens-namehash": "^2.0.8",
-        "solc": "^0.4.20",
-        "testrpc": "0.0.1",
-        "web3-utils": "^1.0.0-beta.31"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@ensdomains/ens/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@ensdomains/ens/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@ensdomains/ens/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/solc": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.26.tgz",
-      "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fs-extra": "^0.30.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
-      },
-      "bin": {
-        "solcjs": "solcjs"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@ensdomains/ens/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@ensdomains/ens/node_modules/yargs": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.1",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.1"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
-      }
-    },
-    "node_modules/@ensdomains/resolver": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.2.4.tgz",
-      "integrity": "sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==",
-      "dev": true
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -2777,244 +2390,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ethereum-waffle/chai": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-3.4.1.tgz",
-      "integrity": "sha512-8mjgjWCe8XSCWuyJgVtJY8sm00VTczGBTDxBejgEBWN/J9x7QD8jdmWW8bfxdnqZbxiDCTvRFL58Wmd254BEqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ethereum-waffle/provider": "^3.4.0",
-        "ethers": "^5.4.7"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-3.4.0.tgz",
-      "integrity": "sha512-a2wxGOoB9F1QFRE+Om7Cz2wn+pxM/o7a0a6cbwhaS2lECJgFzeN9xEkVrKahRkF4gEfXGcuORg4msP0Asxezlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@resolver-engine/imports": "^0.3.3",
-        "@resolver-engine/imports-fs": "^0.3.3",
-        "@typechain/ethers-v5": "^2.0.0",
-        "@types/mkdirp": "^0.5.2",
-        "@types/node-fetch": "^2.5.5",
-        "ethers": "^5.0.1",
-        "mkdirp": "^0.5.1",
-        "node-fetch": "^2.6.1",
-        "solc": "^0.6.3",
-        "ts-generator": "^0.1.1",
-        "typechain": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/@typechain/ethers-v5": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
-      "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ethers": "^5.0.2"
-      },
-      "peerDependencies": {
-        "ethers": "^5.0.0",
-        "typechain": "^3.0.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/solc": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.12.tgz",
-      "integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "command-exists": "^1.2.8",
-        "commander": "3.0.2",
-        "fs-extra": "^0.30.0",
-        "js-sha3": "0.8.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^2.0.0",
-        "semver": "^5.5.0",
-        "tmp": "0.0.33"
-      },
-      "bin": {
-        "solcjs": "solcjs"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/ts-essentials": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.7.tgz",
-      "integrity": "sha512-2E4HIIj4tQJlIHuATRHayv0EfMGK3ris/GRk1E3CFnsZzeNV+hUmelbaTZHLtXaZppM5oLhHRtO04gINC4Jusw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=3.7.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/typechain": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-3.0.0.tgz",
-      "integrity": "sha512-ft4KVmiN3zH4JUFu2WJBrwfHeDf772Tt2d8bssDTo/YcckKW2D+OwFrHXRC6hJvO3mHjFQTihoMV6fJOi0Hngg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "command-line-args": "^4.0.7",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.0",
-        "js-sha3": "^0.8.0",
-        "lodash": "^4.17.15",
-        "ts-essentials": "^6.0.3",
-        "ts-generator": "^0.1.1"
-      },
-      "bin": {
-        "typechain": "dist/cli/cli.js"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/typechain/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/typechain/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@ethereum-waffle/compiler/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/ens": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/ens/-/ens-3.3.0.tgz",
-      "integrity": "sha512-zVIH/5cQnIEgJPg1aV8+ehYicpcfuAisfrtzYh1pN3UbfeqPylFBeBaIZ7xj/xYzlJjkrek/h9VfULl6EX9Aqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ensdomains/ens": "^0.4.4",
-        "@ensdomains/resolver": "^0.2.4",
-        "ethers": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/mock-contract": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-3.3.0.tgz",
-      "integrity": "sha512-apwq0d+2nQxaNwsyLkE+BNMBhZ1MKGV28BtI9WjD3QD2Ztdt1q9II4sKA4VrLTUneYSmkYbJZJxw89f+OpJGyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abi": "^5.0.1",
-        "ethers": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/@ethereum-waffle/provider": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-3.4.0.tgz",
-      "integrity": "sha512-QgseGzpwlzmaHXhqfdzthCGu5a6P1SBF955jQHf/rBkK1Y7gGo2ukt3rXgxgfg/O5eHqRU+r8xw5MzVyVaBscQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ethereum-waffle/ens": "^3.3.0",
-        "ethers": "^5.0.1",
-        "ganache-core": "^2.13.2",
-        "patch-package": "^6.2.2",
-        "postinstall-postinstall": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10.0"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -5913,6 +5288,85 @@
         "node": ">=14"
       }
     },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.3.tgz",
+      "integrity": "sha512-qEE7Drs2HSY+krH09TXm6P9LFogs0BqbUq6wPD7nQRhmJ+p5zoDaIZjM5WL1pHqU5MpGqya3y+BdwmTYBfU5UA==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "chalk": "^2.4.2",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomiclabs/hardhat-ethers": "^2.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^5.0.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers/node_modules/deep-eql": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.0.tgz",
+      "integrity": "sha512-4YM7QHOMBoVWqGPnp3OPPK7+WCIhUR2OTpahlNQFiyTH3QEeiu9MtBiTAJBkfny4PNhpFbV/jm3lv0iCfb40MA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-network-helpers": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.6.tgz",
+      "integrity": "sha512-a35iVD4ycF6AoTfllAnKm96IPIzzHpgKX/ep4oKc2bsUKFfMlacWdyntgC/7d5blyCTXfFssgNAvXDZfzNWVGQ==",
+      "dev": true,
+      "dependencies": {
+        "ethereumjs-util": "^7.1.4"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.9.5"
+      }
+    },
     "node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.0.3.tgz",
@@ -6100,23 +5554,6 @@
       "integrity": "sha512-Gg0IFkT/DW3vOpih4/kMjeZCLYqtfgECLeLXTs7ZDPzcK0cfoc5wKk4nq5n/izCUzdhidO/Utd6ptF9JrWwWVA==",
       "dev": true,
       "peerDependencies": {
-        "ethers": "^5.0.0",
-        "hardhat": "^2.0.0"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-waffle": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.1.tgz",
-      "integrity": "sha512-2YR2V5zTiztSH9n8BYWgtv3Q+EL0N5Ltm1PAr5z20uAY4SkkfylJ98CIqt18XFvxTD5x4K2wKBzddjV9ViDAZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinon-chai": "^3.2.3",
-        "@types/web3": "1.0.19"
-      },
-      "peerDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
-        "ethereum-waffle": "^3.2.0",
         "ethers": "^5.0.0",
         "hardhat": "^2.0.0"
       }
@@ -7095,102 +6532,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@resolver-engine/core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.3.3.tgz",
-      "integrity": "sha512-eB8nEbKDJJBi5p5SrvrvILn4a0h42bKtbCTri3ZxCGt6UvoQyp7HnGOfki944bUjBSHKK3RvgfViHn+kqdXtnQ==",
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "is-url": "^1.2.4",
-        "request": "^2.85.0"
-      }
-    },
-    "node_modules/@resolver-engine/core/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@resolver-engine/fs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.3.3.tgz",
-      "integrity": "sha512-wQ9RhPUcny02Wm0IuJwYMyAG8fXVeKdmhm8xizNByD4ryZlx6PP6kRen+t/haF43cMfmaV7T3Cx6ChOdHEhFUQ==",
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "dependencies": {
-        "@resolver-engine/core": "^0.3.3",
-        "debug": "^3.1.0"
-      }
-    },
-    "node_modules/@resolver-engine/fs/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@resolver-engine/imports": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.3.3.tgz",
-      "integrity": "sha512-anHpS4wN4sRMwsAbMXhMfOD/y4a4Oo0Cw/5+rue7hSwGWsDOQaAU1ClK1OxjUC35/peazxEl8JaSRRS+Xb8t3Q==",
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "dependencies": {
-        "@resolver-engine/core": "^0.3.3",
-        "debug": "^3.1.0",
-        "hosted-git-info": "^2.6.0",
-        "path-browserify": "^1.0.0",
-        "url": "^0.11.0"
-      }
-    },
-    "node_modules/@resolver-engine/imports-fs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.3.3.tgz",
-      "integrity": "sha512-7Pjg/ZAZtxpeyCFlZR5zqYkz+Wdo84ugB5LApwriT8XFeQoLwGUj4tZFFvvCuxaNCcqZzCYbonJgmGObYBzyCA==",
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "dependencies": {
-        "@resolver-engine/fs": "^0.3.3",
-        "@resolver-engine/imports": "^0.3.3",
-        "debug": "^3.1.0"
-      }
-    },
-    "node_modules/@resolver-engine/imports-fs/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@resolver-engine/imports/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@resolver-engine/imports/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -7650,26 +6991,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "node_modules/@solidity-parser/parser": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
@@ -7925,20 +7246,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@trufflesuite/bigint-buffer": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
-      "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-gyp-build": "4.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@typechain/ethers-v5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-7.1.2.tgz",
@@ -8015,6 +7322,15 @@
       "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
     },
     "node_modules/@types/cli-table": {
       "version": "0.3.0",
@@ -8505,27 +7821,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/sinon": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.4.tgz",
-      "integrity": "sha512-fOYjrxQv8zJsqOY6V6ecP4eZhQBxtY80X0er1VVnUIAIZo74jHm8e1vguG5Yt4Iv8W2Wr7TgibB8MfRe32k9pA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinonjs/fake-timers": "^7.1.0"
-      }
-    },
-    "node_modules/@types/sinon-chai": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
-      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
-      }
-    },
     "node_modules/@types/sortablejs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.10.7.tgz",
@@ -8550,30 +7845,12 @@
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "license": "MIT"
     },
-    "node_modules/@types/underscore": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.3.tgz",
-      "integrity": "sha512-Fl1TX1dapfXyDqFg2ic9M+vlXRktcPJrc4PR7sRc7sdVrjavg/JHlbUXBt8qWWqhJrmSqg3RNAkAPRiOYw6Ahw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/uuid": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/web3": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.19.tgz",
-      "integrity": "sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/bn.js": "*",
-        "@types/underscore": "*"
-      }
     },
     "node_modules/@types/webgl2": {
       "version": "0.0.5",
@@ -9292,13 +8569,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -10696,13 +9966,6 @@
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==",
       "license": "CC0-1.0"
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/blueimp-md5": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
@@ -11122,6 +10385,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -11455,6 +10719,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chalk": {
@@ -15263,19 +14539,6 @@
         "node": ">4.0"
       }
     },
-    "node_modules/emittery": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
-      "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
     "node_modules/emoji-picker-react": {
       "version": "3.4.8",
       "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-3.4.8.tgz",
@@ -16352,34 +15615,6 @@
       "resolved": "eth",
       "link": true
     },
-    "node_modules/eth-ens-namehash": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "idna-uts46-hx": "^2.3.1",
-        "js-sha3": "^0.5.7"
-      }
-    },
-    "node_modules/eth-ens-namehash/node_modules/js-sha3": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-sha3": "^0.8.0"
-      }
-    },
     "node_modules/ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
@@ -16402,26 +15637,6 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/ethereum-waffle": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-3.4.0.tgz",
-      "integrity": "sha512-ADBqZCkoSA5Isk486ntKJVjFEawIiC+3HxNqpJqONvh3YXBTNiRfXvJtGuAFLXPG91QaqkGqILEHANAo7j/olQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ethereum-waffle/chai": "^3.4.0",
-        "@ethereum-waffle/compiler": "^3.4.0",
-        "@ethereum-waffle/mock-contract": "^3.3.0",
-        "@ethereum-waffle/provider": "^3.4.0",
-        "ethers": "^5.0.1"
-      },
-      "bin": {
-        "waffle": "bin/waffle"
-      },
-      "engines": {
-        "node": ">=10.0"
       }
     },
     "node_modules/ethereumjs-abi": {
@@ -16459,17 +15674,15 @@
       }
     },
     "node_modules/ethereumjs-util": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.2.tgz",
-      "integrity": "sha512-xCV3PTAhW8Q2k88XZn9VcO4OrjpeXAlDm5LQTaOLp81SjNSSY6+MwuGXrx6vafOMheWSmZGxIXUbue5e9UvUBw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
-      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
         "create-hash": "^1.1.2",
         "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
         "rlp": "^2.2.4"
       },
       "engines": {
@@ -16477,11 +15690,10 @@
       }
     },
     "node_modules/ethereumjs-util/node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "node_modules/ethers": {
       "version": "5.5.2",
@@ -16530,28 +15742,6 @@
         "@ethersproject/web": "5.5.1",
         "@ethersproject/wordlists": "5.5.0"
       }
-    },
-    "node_modules/ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-unit/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -17696,16 +16886,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2"
-      }
-    },
     "node_modules/findup-sync": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
@@ -18219,42 +17399,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/ganache-core": {
-      "name": "ganache",
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@trufflesuite/bigint-buffer": "1.1.9",
-        "emittery": "0.10.0",
-        "keccak": "3.0.1",
-        "leveldown": "6.1.0",
-        "secp256k1": "4.0.2"
-      },
-      "bin": {
-        "ganache": "dist/node/cli.js",
-        "ganache-cli": "dist/node/cli.js"
-      },
-      "optionalDependencies": {
-        "bufferutil": "4.0.5",
-        "utf-8-validate": "5.0.7"
-      }
-    },
-    "node_modules/ganache-core/node_modules/keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/gensync": {
@@ -20532,29 +19676,6 @@
       "integrity": "sha512-K9xInRkVbT3ZsYimD2KVj6B4E93IBvOjEQTryu99WuuN7G+7x3SzA79+yubbX0QRN9V64Gi+L+ulG5QYTVydOg==",
       "license": "ISC"
     },
-    "node_modules/idna-uts46-hx": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
-      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "2.1.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/idna-uts46-hx/node_modules/punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -20920,16 +20041,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/io-ts": {
@@ -22118,13 +21229,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-weakref": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
@@ -22895,16 +21999,6 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
-      }
-    },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -23037,19 +22131,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/lemons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lemons/-/lemons-1.6.0.tgz",
@@ -23117,88 +22198,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/leveldown": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
-      "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "abstract-leveldown": "^7.2.0",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/leveldown/node_modules/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "catering": "^2.0.0",
-        "is-buffer": "^2.0.5",
-        "level-concat-iterator": "^3.0.0",
-        "level-supports": "^2.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/leveldown/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/leveldown/node_modules/level-concat-iterator": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-      "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "catering": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/leveldown/node_modules/level-supports": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-      "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/leven": {
@@ -23766,13 +22765,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true,
       "license": "MIT"
     },
@@ -26295,28 +25287,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/number-to-bn/node_modules/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -26781,18 +25751,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==",
+      "dev": true
     },
     "node_modules/os-name": {
       "version": "3.1.0",
@@ -27261,130 +26224,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/patch-package": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
-      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^2.4.2",
-        "cross-spawn": "^6.0.5",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
-        "is-ci": "^2.0.0",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.0",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^5.6.0",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "npm": ">5"
-      }
-    },
-    "node_modules/patch-package/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/patch-package/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/patch-package/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/patch-package/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/patch-package/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/patch-package/node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/patch-package/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/patch-package/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/path-browserify": {
@@ -27856,14 +26695,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/postinstall-postinstall": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
-      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/preact": {
       "version": "10.5.14",
@@ -32227,12 +31058,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/testrpc": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/testrpc/-/testrpc-0.0.1.tgz",
-      "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
-      "dev": true
-    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -33473,19 +32298,13 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
       "engines": {
         "node": ">=6.14.2"
       }
-    },
-    "node_modules/utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -33769,25 +32588,6 @@
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/web3-utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.6.0.tgz",
-      "integrity": "sha512-bgCAWAeQnJF035YTFxrcHJ5mGEfTi/McsjqldZiXRwlHK7L1PyOqvXiQLE053dlzvy1kdAxWl/sSSfLMyNUAXg==",
-      "dev": true,
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/webpack": {
       "version": "5.63.0",
@@ -34330,19 +33130,6 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
     },
     "node_modules/windows-release": {
       "version": "3.3.3",
@@ -36816,307 +35603,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
-    "@ensdomains/ens": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.5.tgz",
-      "integrity": "sha512-JSvpj1iNMFjK6K+uVl4unqMoa9rf5jopb8cya5UGBWz23Nw8hSNT7efgUx4BTlAPAgpNlEioUfeTyQ6J9ZvTVw==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.2",
-        "eth-ens-namehash": "^2.0.8",
-        "solc": "^0.4.20",
-        "testrpc": "0.0.1",
-        "web3-utils": "^1.0.0-beta.31"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "get-caller-file": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "require-from-string": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "solc": {
-          "version": "0.4.26",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.26.tgz",
-          "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^0.30.0",
-            "memorystream": "^0.3.1",
-            "require-from-string": "^1.1.0",
-            "semver": "^5.3.0",
-            "yargs": "^4.7.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "y18n": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "4.8.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-          "dev": true,
-          "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
-          }
-        }
-      }
-    },
-    "@ensdomains/resolver": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.2.4.tgz",
-      "integrity": "sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==",
-      "dev": true
-    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -37155,189 +35641,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
-      }
-    },
-    "@ethereum-waffle/chai": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-3.4.1.tgz",
-      "integrity": "sha512-8mjgjWCe8XSCWuyJgVtJY8sm00VTczGBTDxBejgEBWN/J9x7QD8jdmWW8bfxdnqZbxiDCTvRFL58Wmd254BEqQ==",
-      "dev": true,
-      "requires": {
-        "@ethereum-waffle/provider": "^3.4.0",
-        "ethers": "^5.4.7"
-      }
-    },
-    "@ethereum-waffle/compiler": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-3.4.0.tgz",
-      "integrity": "sha512-a2wxGOoB9F1QFRE+Om7Cz2wn+pxM/o7a0a6cbwhaS2lECJgFzeN9xEkVrKahRkF4gEfXGcuORg4msP0Asxezlw==",
-      "dev": true,
-      "requires": {
-        "@resolver-engine/imports": "^0.3.3",
-        "@resolver-engine/imports-fs": "^0.3.3",
-        "@typechain/ethers-v5": "^2.0.0",
-        "@types/mkdirp": "^0.5.2",
-        "@types/node-fetch": "^2.5.5",
-        "ethers": "^5.0.1",
-        "mkdirp": "^0.5.1",
-        "node-fetch": "^2.6.1",
-        "solc": "^0.6.3",
-        "ts-generator": "^0.1.1",
-        "typechain": "^3.0.0"
-      },
-      "dependencies": {
-        "@typechain/ethers-v5": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
-          "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
-          "dev": true,
-          "requires": {
-            "ethers": "^5.0.2"
-          }
-        },
-        "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "solc": {
-          "version": "0.6.12",
-          "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.12.tgz",
-          "integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
-          "dev": true,
-          "requires": {
-            "command-exists": "^1.2.8",
-            "commander": "3.0.2",
-            "fs-extra": "^0.30.0",
-            "js-sha3": "0.8.0",
-            "memorystream": "^0.3.1",
-            "require-from-string": "^2.0.0",
-            "semver": "^5.5.0",
-            "tmp": "0.0.33"
-          }
-        },
-        "ts-essentials": {
-          "version": "6.0.7",
-          "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.7.tgz",
-          "integrity": "sha512-2E4HIIj4tQJlIHuATRHayv0EfMGK3ris/GRk1E3CFnsZzeNV+hUmelbaTZHLtXaZppM5oLhHRtO04gINC4Jusw==",
-          "dev": true,
-          "requires": {}
-        },
-        "typechain": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/typechain/-/typechain-3.0.0.tgz",
-          "integrity": "sha512-ft4KVmiN3zH4JUFu2WJBrwfHeDf772Tt2d8bssDTo/YcckKW2D+OwFrHXRC6hJvO3mHjFQTihoMV6fJOi0Hngg==",
-          "dev": true,
-          "requires": {
-            "command-line-args": "^4.0.7",
-            "debug": "^4.1.1",
-            "fs-extra": "^7.0.0",
-            "js-sha3": "^0.8.0",
-            "lodash": "^4.17.15",
-            "ts-essentials": "^6.0.3",
-            "ts-generator": "^0.1.1"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-              "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            },
-            "jsonfile": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-              "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6"
-              }
-            }
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
-    },
-    "@ethereum-waffle/ens": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/ens/-/ens-3.3.0.tgz",
-      "integrity": "sha512-zVIH/5cQnIEgJPg1aV8+ehYicpcfuAisfrtzYh1pN3UbfeqPylFBeBaIZ7xj/xYzlJjkrek/h9VfULl6EX9Aqw==",
-      "dev": true,
-      "requires": {
-        "@ensdomains/ens": "^0.4.4",
-        "@ensdomains/resolver": "^0.2.4",
-        "ethers": "^5.0.1"
-      }
-    },
-    "@ethereum-waffle/mock-contract": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-3.3.0.tgz",
-      "integrity": "sha512-apwq0d+2nQxaNwsyLkE+BNMBhZ1MKGV28BtI9WjD3QD2Ztdt1q9II4sKA4VrLTUneYSmkYbJZJxw89f+OpJGyw==",
-      "dev": true,
-      "requires": {
-        "@ethersproject/abi": "^5.0.1",
-        "ethers": "^5.0.1"
-      }
-    },
-    "@ethereum-waffle/provider": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-3.4.0.tgz",
-      "integrity": "sha512-QgseGzpwlzmaHXhqfdzthCGu5a6P1SBF955jQHf/rBkK1Y7gGo2ukt3rXgxgfg/O5eHqRU+r8xw5MzVyVaBscQ==",
-      "dev": true,
-      "requires": {
-        "@ethereum-waffle/ens": "^3.3.0",
-        "ethers": "^5.0.1",
-        "ganache-core": "^2.13.2",
-        "patch-package": "^6.2.2",
-        "postinstall-postinstall": "^2.1.0"
       }
     },
     "@ethersproject/abi": {
@@ -39396,6 +37699,66 @@
         "rustbn.js": "~0.2.0"
       }
     },
+    "@nomicfoundation/hardhat-chai-matchers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.3.tgz",
+      "integrity": "sha512-qEE7Drs2HSY+krH09TXm6P9LFogs0BqbUq6wPD7nQRhmJ+p5zoDaIZjM5WL1pHqU5MpGqya3y+BdwmTYBfU5UA==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.1.2",
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "chalk": "^2.4.2",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "deep-eql": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.0.tgz",
+          "integrity": "sha512-4YM7QHOMBoVWqGPnp3OPPK7+WCIhUR2OTpahlNQFiyTH3QEeiu9MtBiTAJBkfny4PNhpFbV/jm3lv0iCfb40MA==",
+          "dev": true,
+          "requires": {
+            "type-detect": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@nomicfoundation/hardhat-network-helpers": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.6.tgz",
+      "integrity": "sha512-a35iVD4ycF6AoTfllAnKm96IPIzzHpgKX/ep4oKc2bsUKFfMlacWdyntgC/7d5blyCTXfFssgNAvXDZfzNWVGQ==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-util": "^7.1.4"
+      }
+    },
     "@nomicfoundation/solidity-analyzer": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.0.3.tgz",
@@ -39490,16 +37853,6 @@
       "integrity": "sha512-Gg0IFkT/DW3vOpih4/kMjeZCLYqtfgECLeLXTs7ZDPzcK0cfoc5wKk4nq5n/izCUzdhidO/Utd6ptF9JrWwWVA==",
       "dev": true,
       "requires": {}
-    },
-    "@nomiclabs/hardhat-waffle": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.1.tgz",
-      "integrity": "sha512-2YR2V5zTiztSH9n8BYWgtv3Q+EL0N5Ltm1PAr5z20uAY4SkkfylJ98CIqt18XFvxTD5x4K2wKBzddjV9ViDAZQ==",
-      "dev": true,
-      "requires": {
-        "@types/sinon-chai": "^3.2.3",
-        "@types/web3": "1.0.19"
-      }
     },
     "@npmcli/map-workspaces": {
       "version": "2.0.4",
@@ -40242,101 +38595,6 @@
         }
       }
     },
-    "@resolver-engine/core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.3.3.tgz",
-      "integrity": "sha512-eB8nEbKDJJBi5p5SrvrvILn4a0h42bKtbCTri3ZxCGt6UvoQyp7HnGOfki944bUjBSHKK3RvgfViHn+kqdXtnQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.1.0",
-        "is-url": "^1.2.4",
-        "request": "^2.85.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "@resolver-engine/fs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.3.3.tgz",
-      "integrity": "sha512-wQ9RhPUcny02Wm0IuJwYMyAG8fXVeKdmhm8xizNByD4ryZlx6PP6kRen+t/haF43cMfmaV7T3Cx6ChOdHEhFUQ==",
-      "dev": true,
-      "requires": {
-        "@resolver-engine/core": "^0.3.3",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "@resolver-engine/imports": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.3.3.tgz",
-      "integrity": "sha512-anHpS4wN4sRMwsAbMXhMfOD/y4a4Oo0Cw/5+rue7hSwGWsDOQaAU1ClK1OxjUC35/peazxEl8JaSRRS+Xb8t3Q==",
-      "dev": true,
-      "requires": {
-        "@resolver-engine/core": "^0.3.3",
-        "debug": "^3.1.0",
-        "hosted-git-info": "^2.6.0",
-        "path-browserify": "^1.0.0",
-        "url": "^0.11.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-          "dev": true
-        }
-      }
-    },
-    "@resolver-engine/imports-fs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.3.3.tgz",
-      "integrity": "sha512-7Pjg/ZAZtxpeyCFlZR5zqYkz+Wdo84ugB5LApwriT8XFeQoLwGUj4tZFFvvCuxaNCcqZzCYbonJgmGObYBzyCA==",
-      "dev": true,
-      "requires": {
-        "@resolver-engine/fs": "^0.3.3",
-        "@resolver-engine/imports": "^0.3.3",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -40676,24 +38934,6 @@
         }
       }
     },
-    "@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "@solidity-parser/parser": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
@@ -40910,15 +39150,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@trufflesuite/bigint-buffer": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
-      "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
-      "dev": true,
-      "requires": {
-        "node-gyp-build": "4.3.0"
-      }
-    },
     "@typechain/ethers-v5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-7.1.2.tgz",
@@ -40976,6 +39207,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
       "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
     },
     "@types/cli-table": {
       "version": "0.3.0",
@@ -41410,25 +39650,6 @@
       "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==",
       "dev": true
     },
-    "@types/sinon": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.4.tgz",
-      "integrity": "sha512-fOYjrxQv8zJsqOY6V6ecP4eZhQBxtY80X0er1VVnUIAIZo74jHm8e1vguG5Yt4Iv8W2Wr7TgibB8MfRe32k9pA==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/fake-timers": "^7.1.0"
-      }
-    },
-    "@types/sinon-chai": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
-      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
-      }
-    },
     "@types/sortablejs": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.10.7.tgz",
@@ -41450,27 +39671,11 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
-    "@types/underscore": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.3.tgz",
-      "integrity": "sha512-Fl1TX1dapfXyDqFg2ic9M+vlXRktcPJrc4PR7sRc7sdVrjavg/JHlbUXBt8qWWqhJrmSqg3RNAkAPRiOYw6Ahw==",
-      "dev": true
-    },
     "@types/uuid": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
-    },
-    "@types/web3": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@types/web3/-/web3-1.0.19.tgz",
-      "integrity": "sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==",
-      "dev": true,
-      "requires": {
-        "@types/bn.js": "*",
-        "@types/underscore": "*"
-      }
     },
     "@types/webgl2": {
       "version": "0.0.5",
@@ -41951,12 +40156,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true
-    },
-    "@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
     "abab": {
@@ -42964,12 +41163,6 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
       "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
-    },
     "blueimp-md5": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
@@ -43290,6 +41483,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "optional": true,
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -43520,6 +41714,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chalk": {
@@ -46434,12 +44637,6 @@
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
       "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
     },
-    "emittery": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
-      "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
-      "dev": true
-    },
     "emoji-picker-react": {
       "version": "3.4.8",
       "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-3.4.8.tgz",
@@ -47203,8 +45400,9 @@
         "@graphprotocol/graph-cli": "0.24.1",
         "@graphprotocol/graph-ts": "0.24.1",
         "@iarna/toml": "^2.2.5",
+        "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.6",
         "@nomiclabs/hardhat-ethers": "^2.1.1",
-        "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@projectsophon/workspace": "^1.0.0",
         "@solidstate/contracts": "0.0.29",
         "@solidstate/hardhat-4byte-uploader": "^1.0.2",
@@ -47227,7 +45425,6 @@
         "dockerode": "^3.2.1",
         "dotenv": "^10.0.0",
         "eslint": "^7.30.0",
-        "ethereum-waffle": "^3.2.2",
         "ethers": "^5.5.1",
         "hardhat": "^2.11.2",
         "hardhat-abi-exporter": "^2.10.0",
@@ -47263,33 +45460,6 @@
         }
       }
     },
-    "eth-ens-namehash": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
-      "dev": true,
-      "requires": {
-        "idna-uts46-hx": "^2.3.1",
-        "js-sha3": "^0.5.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
-        }
-      }
-    },
-    "ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
-      "dev": true,
-      "requires": {
-        "js-sha3": "^0.8.0"
-      }
-    },
     "ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
@@ -47311,19 +45481,6 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "ethereum-waffle": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-3.4.0.tgz",
-      "integrity": "sha512-ADBqZCkoSA5Isk486ntKJVjFEawIiC+3HxNqpJqONvh3YXBTNiRfXvJtGuAFLXPG91QaqkGqILEHANAo7j/olQ==",
-      "dev": true,
-      "requires": {
-        "@ethereum-waffle/chai": "^3.4.0",
-        "@ethereum-waffle/compiler": "^3.4.0",
-        "@ethereum-waffle/mock-contract": "^3.3.0",
-        "@ethereum-waffle/provider": "^3.4.0",
-        "ethers": "^5.0.1"
       }
     },
     "ethereumjs-abi": {
@@ -47363,23 +45520,22 @@
       }
     },
     "ethereumjs-util": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.2.tgz",
-      "integrity": "sha512-xCV3PTAhW8Q2k88XZn9VcO4OrjpeXAlDm5LQTaOLp81SjNSSY6+MwuGXrx6vafOMheWSmZGxIXUbue5e9UvUBw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dev": true,
       "requires": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
         "create-hash": "^1.1.2",
         "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
         "rlp": "^2.2.4"
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
           "dev": true
         }
       }
@@ -47419,24 +45575,6 @@
         "@ethersproject/wallet": "5.5.0",
         "@ethersproject/web": "5.5.1",
         "@ethersproject/wordlists": "5.5.0"
-      }
-    },
-    "ethjs-unit": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
       }
     },
     "ethjs-util": {
@@ -48292,15 +46430,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
-      "requires": {
-        "micromatch": "^4.0.2"
-      }
-    },
     "findup-sync": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
@@ -48676,31 +46805,6 @@
       "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
       "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg=",
       "dev": true
-    },
-    "ganache-core": {
-      "version": "npm:ganache@7.0.3",
-      "dev": true,
-      "requires": {
-        "@trufflesuite/bigint-buffer": "1.1.9",
-        "bufferutil": "4.0.5",
-        "emittery": "0.10.0",
-        "keccak": "3.0.1",
-        "leveldown": "6.1.0",
-        "secp256k1": "4.0.2",
-        "utf-8-validate": "5.0.7"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-          "dev": true,
-          "requires": {
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -50336,23 +48440,6 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-5.0.8.tgz",
       "integrity": "sha512-K9xInRkVbT3ZsYimD2KVj6B4E93IBvOjEQTryu99WuuN7G+7x3SzA79+yubbX0QRN9V64Gi+L+ulG5QYTVydOg=="
     },
-    "idna-uts46-hx": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
-      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
-      "dev": true,
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-          "dev": true
-        }
-      }
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -50599,12 +48686,6 @@
         "from2": "^2.1.1",
         "p-is-promise": "^1.1.0"
       }
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
     },
     "io-ts": {
       "version": "1.10.4",
@@ -51449,12 +49530,6 @@
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
     "is-weakref": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
@@ -52043,15 +50118,6 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11"
-      }
-    },
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
@@ -52150,15 +50216,6 @@
         }
       }
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "lemons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lemons/-/lemons-1.6.0.tgz",
@@ -52199,58 +50256,6 @@
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
           }
-        }
-      }
-    },
-    "leveldown": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
-      "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "^7.2.0",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-          "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^6.0.3",
-            "catering": "^2.0.0",
-            "is-buffer": "^2.0.5",
-            "level-concat-iterator": "^3.0.0",
-            "level-supports": "^2.0.1",
-            "queue-microtask": "^1.2.3"
-          }
-        },
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "level-concat-iterator": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
-          "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
-          "dev": true,
-          "requires": {
-            "catering": "^2.1.0"
-          }
-        },
-        "level-supports": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
-          "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
-          "dev": true
         }
       }
     },
@@ -52673,12 +50678,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.camelcase": {
@@ -54588,24 +52587,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
-      }
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -54928,14 +52909,11 @@
         }
       }
     },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "^1.0.0"
-      }
+    "ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==",
+      "dev": true
     },
     "os-name": {
       "version": "3.1.0",
@@ -55265,93 +53243,6 @@
         }
       }
     },
-    "patch-package": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
-      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
-      "dev": true,
-      "requires": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^2.4.2",
-        "cross-spawn": "^6.0.5",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^7.0.1",
-        "is-ci": "^2.0.0",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.0",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^5.6.0",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "slash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
-    },
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -55665,12 +53556,6 @@
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
       }
-    },
-    "postinstall-postinstall": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
-      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
-      "dev": true
     },
     "preact": {
       "version": "10.5.14",
@@ -58847,12 +56732,6 @@
         "typical": "^2.6.0"
       }
     },
-    "testrpc": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/testrpc/-/testrpc-0.0.1.tgz",
-      "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
-      "dev": true
-    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -59763,15 +57642,10 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "optional": true,
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
-    },
-    "utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -59994,21 +57868,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
-    },
-    "web3-utils": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.6.0.tgz",
-      "integrity": "sha512-bgCAWAeQnJF035YTFxrcHJ5mGEfTi/McsjqldZiXRwlHK7L1PyOqvXiQLE053dlzvy1kdAxWl/sSSfLMyNUAXg==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.11.9",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      }
     },
     "webpack": {
       "version": "5.63.0",
@@ -60360,12 +58219,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-      "dev": true
-    },
-    "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
     "windows-release": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,5 @@
     "prettier-plugin-organize-imports": "^2.3.2",
     "prettier-plugin-solidity": "=1.0.0-beta.19",
     "typescript": "4.5.x"
-  },
-  "resolutions": {
-    "ganache-core": "npm:ganache@^7.0.3"
   }
 }


### PR DESCRIPTION
Builds upon #4 

This replaces the hardhat-waffles plugin with newer tools written and recommended by the hardhat team. This change removed over 100 transitive dependencies from the project.