### PR TITLE
chore: Add development workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,75 @@
+name: dev
+on: [pull_request, push]
+env:
+  CI: true
+
+jobs:
+  prettier:
+    name: Format code
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Setup node & npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Format
+        run: npm run format
+
+      # Setup a "bot" name & email for our commit step
+      # using the GitHub Actions bot user: https://github.community/t/github-actions-bot-email-address/17204/6
+      - name: Configure git
+        run: |
+          git config --global user.name github-actions[bot]
+          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      # Only commit if there's a change. Ref https://stackoverflow.com/a/8123841
+      - name: Commit formatted code
+        run: |
+          git add .
+          git diff-index --quiet HEAD || git commit -m 'chore: Format code'
+          git push
+
+  test:
+    name: Tests for Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Setup node & npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test

--- a/eth/test/DFArtifacts.test.ts
+++ b/eth/test/DFArtifacts.test.ts
@@ -317,7 +317,8 @@ describe('DarkForestArtifacts', function () {
   });
 
   it('should mint randomly', async function () {
-    this.timeout(1000 * 60);
+    // This can take upwards of 90000ms in CI
+    this.timeout(0);
 
     await conquerUnownedPlanet(world, world.user1Core, SPAWN_PLANET_1, LVL3_SPACETIME_1);
 

--- a/eth/test/DFArtifacts.test.ts
+++ b/eth/test/DFArtifacts.test.ts
@@ -572,6 +572,9 @@ describe('DarkForestArtifacts', function () {
 
   describe('wormhole', function () {
     it('should increase movement speed, in both directions', async function () {
+      // This can take an upwards of 32000ms
+      this.timeout(0);
+
       const from = SPAWN_PLANET_1;
       const to = LVL0_PLANET;
       await conquerUnownedPlanet(world, world.user1Core, from, LVL3_UNOWNED_NEBULA);


### PR DESCRIPTION
This adds formatting, linting, and testing as a GitHub Actions workflow. When you push, it'll format your code if it doesn't match the style and it'll run linting and testing on each push & PR. The reason we want to run on push **and** PR is that they use different "base branches", a push uses itself as a base branch, but a PR uses the target branch as the base branch. Even though it'll take longer for CI to run, it can catch some problems that only occur after a merge.

This also runs CI on linux, mac, and windows to ensure we maintain compatibility with all these systems.

I noticed that some of the tests take **crazy** long to run on the MacOS runner so I needed to disable the timeout on a couple tests. I also noticed that there's is a flakey test or two related to the move DoS on MacOS that may be caused by the runner being so slow? It's unclear.