### PR TITLE
fix: Always indicate contract owner is whitelisted

### DIFF
--- a/client/src/Frontend/Pages/GameLandingPage.tsx
+++ b/client/src/Frontend/Pages/GameLandingPage.tsx
@@ -430,14 +430,11 @@ export function GameLandingPage({ match, location }: RouteComponentProps<{ contr
           loadDiamondContract
         );
         const isWhitelisted = await whitelist.isWhitelisted(playerAddress);
-        // TODO(#2329): isWhitelisted should just check the contractOwner
-        const adminAddress = address(await whitelist.adminAddress());
 
         terminal.current?.println('');
         terminal.current?.print('Checking if whitelisted... ');
 
-        // TODO(#2329): isWhitelisted should just check the contractOwner
-        if (isWhitelisted || playerAddress === adminAddress) {
+        if (isWhitelisted) {
           terminal.current?.println('Player whitelisted.');
           terminal.current?.println('');
           terminal.current?.println(`Welcome, player ${playerAddress}.`);

--- a/eth/contracts/facets/DFWhitelistFacet.sol
+++ b/eth/contracts/facets/DFWhitelistFacet.sol
@@ -26,6 +26,9 @@ contract DFWhitelistFacet is WithStorage {
         if (!ws().enabled) {
             return true;
         }
+        if (LibPermissions.contractOwner() == _addr) {
+            return true;
+        }
         return ws().allowedAccounts[_addr];
     }
 

--- a/eth/test/DFWhitelist.test.ts
+++ b/eth/test/DFWhitelist.test.ts
@@ -25,6 +25,14 @@ describe('DarkForestWhitelist', function () {
     world = await loadFixture(worldFixture);
   });
 
+  it('always indicates that the admin is whitelisted', async function () {
+    expect(await world.contract.isWhitelisted(world.deployer.address)).to.eq(true);
+  });
+
+  it('indicates that an address is not whitelisted before it uses a key', async function () {
+    expect(await world.contract.isWhitelisted(world.user1.address)).to.eq(false);
+  });
+
   it('allows a user to register with a valid key', async function () {
     const whitelistArgs = await makeWhitelistArgs(keys[0], world.user1.address as EthAddress);
     await world.user1Core.useKey(...whitelistArgs);


### PR DESCRIPTION
As you can see in the deleted client code, this was a TODO in the original DF codebase. Since I need to translate the client code, I figured it'd be easier to just implement this and so it will clean up both!